### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/inc/Probe.pm
+++ b/inc/Probe.pm
@@ -105,7 +105,7 @@ my $PARAMS_TEMPLATE = <<PARAMS;
 
 package Term::Size::Perl::Params; 
 
-# created @{[scalar localtime]}
+# created @{[scalar localtime($ENV{SOURCE_DATE_EPOCH} or time)]}
 
 use vars qw(\$VERSION);
 \$VERSION = '@{[MM->parse_version('Perl.pm')]}';


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Alternative would be to just drop that line.

See https://reproducible-builds.org/ for why this matters.